### PR TITLE
align installation doc with other tendr projects

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -2,11 +2,25 @@
 Installation
 ============
 
+Since there is no stable release yet, the only option is to install the project
+from the source.
+
+Development version from the source
+-----------------------------------
+
 Installation of latest dev version from the source code::
 
     $ git clone https://github.com/Tendrl/bridge_common.git
     $ cd bridge_common
     $ mkvirtualenv bridge_common
     $ pip install .
-    $ cp etc/tendrl/tendrl.conf.sample /etc/tendrl/tendrl.conf  (Edit conf
-    file as required)
+
+Note that we use virtualenvwrapper_ here to create and activate `python virtual
+enviroment`_, where we install the *bridge common* via pip.
+
+.. _virtualenvwrapper: https://virtualenvwrapper.readthedocs.io/en/latest/
+.. _`python virtual enviroment`: https://virtualenv.pypa.io/en/stable/
+
+And finally, create and edit config file as required::
+
+    $ cp etc/tendrl/tendrl.conf.sample /etc/tendrl/tendrl.conf


### PR DESCRIPTION
Based on @r0h4n comment https://github.com/Tendrl/bridge_common/pull/28#issuecomment-253431571, I'm proposing this change, which is part of update of installation.rst file of all python tendrl projects.
