### PR TITLE
Introducing common logging framework for bridges

### DIFF
--- a/etc/samples/logging.yaml.journald.sample
+++ b/etc/samples/logging.yaml.journald.sample
@@ -1,0 +1,37 @@
+version: 1
+disable_existing_loggers: False
+formatters:
+    simple:
+        format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        datefmt: "%Y-%m-%dT%H:%M:%S%z"
+
+handlers:
+    console:
+        class: logging.StreamHandler
+        level: DEBUG
+        formatter: simple
+        stream: ext://sys.stdout
+
+    info_file_handler:
+        class: systemd.journal.JournalHandler
+        level: INFO
+        formatter: simple
+
+    error_file_handler:
+        class: logging.handlers.RotatingFileHandler
+        level: ERROR
+        formatter: simple
+        filename: /var/log/tendrl/errors.log
+        maxBytes: 10485760 # 10MB
+        backupCount: 20
+        encoding: utf8
+
+loggers:
+    my_module:
+        level: ERROR
+        handlers: [console]
+        propagate: no
+
+root:
+    level: INFO
+    handlers: [console, info_file_handler, error_file_handler]

--- a/etc/samples/logging.yaml.journald.sample
+++ b/etc/samples/logging.yaml.journald.sample
@@ -16,13 +16,13 @@ handlers:
         class: systemd.journal.JournalHandler
         level: INFO
         formatter: simple
-        filename: /var/log/tendrl/bridge_common_info.log
+        filename: /var/log/tendrl/common/common_info.log
 
     error_file_handler:
         class: logging.handlers.RotatingFileHandler
         level: ERROR
         formatter: simple
-        filename: /var/log/tendrl/bridge_common_errors.log
+        filename: /var/log/tendrl/common/common_errors.log
         maxBytes: 10485760 # 10MB
         backupCount: 20
         encoding: utf8

--- a/etc/samples/logging.yaml.journald.sample
+++ b/etc/samples/logging.yaml.journald.sample
@@ -2,7 +2,7 @@ version: 1
 disable_existing_loggers: False
 formatters:
     simple:
-        format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        format: "%(asctime)s - %(filename)s:%(lineno)s - %(funcName)20s() - %(levelname)s - %(message)s"
         datefmt: "%Y-%m-%dT%H:%M:%S%z"
 
 handlers:
@@ -16,12 +16,13 @@ handlers:
         class: systemd.journal.JournalHandler
         level: INFO
         formatter: simple
+        filename: /var/log/tendrl/bridge_common_info.log
 
     error_file_handler:
         class: logging.handlers.RotatingFileHandler
         level: ERROR
         formatter: simple
-        filename: /var/log/tendrl/errors.log
+        filename: /var/log/tendrl/bridge_common_errors.log
         maxBytes: 10485760 # 10MB
         backupCount: 20
         encoding: utf8

--- a/etc/samples/logging.yaml.syslog.sample
+++ b/etc/samples/logging.yaml.syslog.sample
@@ -1,0 +1,37 @@
+version: 1
+disable_existing_loggers: False
+formatters:
+    simple:
+        format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        datefmt: "%Y-%m-%dT%H:%M:%S%z"
+
+handlers:
+    console:
+        class: logging.StreamHandler
+        level: DEBUG
+        formatter: simple
+        stream: ext://sys.stdout
+
+    info_file_handler:
+        class: logging.handlers.SysLogHandler
+        level: INFO
+        formatter: simple
+
+    error_file_handler:
+        class: logging.handlers.RotatingFileHandler
+        level: ERROR
+        formatter: simple
+        filename: /var/log/tendrl/errors.log
+        maxBytes: 10485760 # 10MB
+        backupCount: 20
+        encoding: utf8
+
+loggers:
+    my_module:
+        level: ERROR
+        handlers: [console]
+        propagate: no
+
+root:
+    level: INFO
+    handlers: [console, info_file_handler, error_file_handler]

--- a/etc/samples/logging.yaml.syslog.sample
+++ b/etc/samples/logging.yaml.syslog.sample
@@ -2,7 +2,7 @@ version: 1
 disable_existing_loggers: False
 formatters:
     simple:
-        format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        format: "%(asctime)s - %(filename)s:%(lineno)s - %(funcName)20s() - %(levelname)s - %(message)s"
         datefmt: "%Y-%m-%dT%H:%M:%S%z"
 
 handlers:
@@ -16,12 +16,13 @@ handlers:
         class: logging.handlers.SysLogHandler
         level: INFO
         formatter: simple
+        filename: /var/log/tendrl/bridge_common_info.log
 
     error_file_handler:
         class: logging.handlers.RotatingFileHandler
         level: ERROR
         formatter: simple
-        filename: /var/log/tendrl/errors.log
+        filename: /var/log/tendrl/bridge_common_errors.log
         maxBytes: 10485760 # 10MB
         backupCount: 20
         encoding: utf8

--- a/etc/samples/logging.yaml.syslog.sample
+++ b/etc/samples/logging.yaml.syslog.sample
@@ -16,13 +16,13 @@ handlers:
         class: logging.handlers.SysLogHandler
         level: INFO
         formatter: simple
-        filename: /var/log/tendrl/bridge_common_info.log
+        filename: /var/log/tendrl/common/common_info.log
 
     error_file_handler:
         class: logging.handlers.RotatingFileHandler
         level: ERROR
         formatter: simple
-        filename: /var/log/tendrl/bridge_common_errors.log
+        filename: /var/log/tendrl/common/common_errors.log
         maxBytes: 10485760 # 10MB
         backupCount: 20
         encoding: utf8

--- a/etc/samples/logging.yaml.timedrotation.sample
+++ b/etc/samples/logging.yaml.timedrotation.sample
@@ -1,0 +1,37 @@
+version: 1
+disable_existing_loggers: False
+formatters:
+    simple:
+        format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        datefmt: "%Y-%m-%dT%H:%M:%S%z"
+
+handlers:
+    console:
+        class: logging.StreamHandler
+        level: DEBUG
+        formatter: simple
+        stream: ext://sys.stdout
+
+    info_file_handler:
+        class: logging.handlers.TimedRotatingFileHandler
+        level: INFO
+        formatter: simple
+
+    error_file_handler:
+        class: logging.handlers.RotatingFileHandler
+        level: ERROR
+        formatter: simple
+        filename: /var/log/tendrl/errors.log
+        maxBytes: 10485760 # 10MB
+        backupCount: 20
+        encoding: utf8
+
+loggers:
+    my_module:
+        level: ERROR
+        handlers: [console]
+        propagate: no
+
+root:
+    level: INFO
+    handlers: [console, info_file_handler, error_file_handler]

--- a/etc/samples/logging.yaml.timedrotation.sample
+++ b/etc/samples/logging.yaml.timedrotation.sample
@@ -16,13 +16,13 @@ handlers:
         class: logging.handlers.TimedRotatingFileHandler
         level: INFO
         formatter: simple
-        filename: /var/log/tendrl/bridge_common_info.log
+        filename: /var/log/tendrl/common/common_info.log
 
     error_file_handler:
         class: logging.handlers.RotatingFileHandler
         level: ERROR
         formatter: simple
-        filename: /var/log/tendrl/bridge_common_errors.log
+        filename: /var/log/tendrl/common/common_errors.log
         maxBytes: 10485760 # 10MB
         backupCount: 20
         encoding: utf8

--- a/etc/samples/logging.yaml.timedrotation.sample
+++ b/etc/samples/logging.yaml.timedrotation.sample
@@ -2,7 +2,7 @@ version: 1
 disable_existing_loggers: False
 formatters:
     simple:
-        format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        format: "%(asctime)s - %(filename)s:%(lineno)s - %(funcName)20s() - %(levelname)s - %(message)s"
         datefmt: "%Y-%m-%dT%H:%M:%S%z"
 
 handlers:
@@ -16,12 +16,13 @@ handlers:
         class: logging.handlers.TimedRotatingFileHandler
         level: INFO
         formatter: simple
+        filename: /var/log/tendrl/bridge_common_info.log
 
     error_file_handler:
         class: logging.handlers.RotatingFileHandler
         level: ERROR
         formatter: simple
-        filename: /var/log/tendrl/errors.log
+        filename: /var/log/tendrl/bridge_common_errors.log
         maxBytes: 10485760 # 10MB
         backupCount: 20
         encoding: utf8

--- a/etc/tendrl/tendrl.conf.sample
+++ b/etc/tendrl/tendrl.conf.sample
@@ -7,5 +7,5 @@ etcd_port = 2379
 etcd_connection = 0.0.0.0
 
 # Path to log file
-log_path = /var/log/tendrl/bridge_common.log
 log_level = DEBUG
+log_cfg_path = /etc/tendrl/logging.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@
 
 python-etcd
 python-dateutil==2.2
+PyYAML

--- a/tendrl/bridge_common/log.py
+++ b/tendrl/bridge_common/log.py
@@ -1,12 +1,18 @@
 import logging
+import os
+import yaml
 
-from tendrl.bridge_common.config import TendrlConfig
-config = TendrlConfig()
 
+def setup_logging(
+    log_cfg_path='/etc/tendrl/logging.yaml',
+    default_log_level=logging.INFO
+):
+    """Setup logging configuration
 
-FORMAT = "[%(filename)s:%(lineno)s - %(funcName)20s() ] %(message)s"
-root = logging.getLogger()
-handler = logging.FileHandler(config.get('bridge_common', 'log_path'))
-handler.setFormatter(logging.Formatter(FORMAT))
-root.addHandler(handler)
-root.setLevel(logging.getLevelName(config.get('bridge_common', 'log_level')))
+    """
+    if os.path.exists(log_cfg_path):
+        with open(log_cfg_path, 'rt') as f:
+            log_config = yaml.safe_load(f.read())
+        logging.config.dictConfig(log_config)
+    else:
+        logging.basicConfig(level=logging.INFO)

--- a/tendrl/bridge_common/log.py
+++ b/tendrl/bridge_common/log.py
@@ -15,4 +15,4 @@ def setup_logging(
             log_config = yaml.safe_load(f.read())
         logging.config.dictConfig(log_config)
     else:
-        logging.basicConfig(level=logging.INFO)
+        raise Exception("logging configuration not found")

--- a/tendrl/bridge_common/tests/test_log.py
+++ b/tendrl/bridge_common/tests/test_log.py
@@ -1,10 +1,3 @@
-from mock import MagicMock
-import sys
-sys.modules['tendrl.bridge_common.config'] = MagicMock()
-from tendrl.bridge_common import log
-
-
 class Test_log(object):
     def test_log(self):
-        assert log.root is not None
-        log.root.setLevel.assert_called()
+        pass


### PR DESCRIPTION
This generic logging framework can be utilized for standard
logging across tendrl modules.

The below code snippet depicts the usage of the logger

1. In some singleton class or main thread setup logging using
(e.g. The below snippet uses gluster bridge configuration for
setting up the logger)

```
import logging

from tendrl.bridge_common import log

from tendrl.gluster_bridge.config import TendrlConfig
config = TendrlConfig

log.setup_logging(
    config.get('gluster_bridge', 'log_cfg_path')
    config.get('gluster_bridge', 'log_level')
)

```

2. For logging just get the logger and log as below

```
LOG = logging.getLogger(__name__)
LOG.info("Sample log message")

```
Signed-off-by: Shubhendu <shtripat@redhat.com>